### PR TITLE
clean requirements (issue #52)

### DIFF
--- a/ci/python_310.yaml
+++ b/ci/python_310.yaml
@@ -6,11 +6,9 @@ channels:
 dependencies:
     - python=3.10
     - configargparse
-    - geopandas
     - joblib
     - jpype1
     - numpy
     - pandas
     - psutil
     - requests
-    - shapely

--- a/ci/python_38.yaml
+++ b/ci/python_38.yaml
@@ -6,11 +6,9 @@ channels:
 dependencies:
     - python=3.8
     - configargparse
-    - geopandas
     - joblib
     - jpype1
     - numpy
     - pandas
     - psutil
     - requests
-    - shapely

--- a/ci/python_39.yaml
+++ b/ci/python_39.yaml
@@ -6,11 +6,9 @@ channels:
 dependencies:
     - python=3.9
     - configargparse
-    - geopandas
     - joblib
     - jpype1
     - numpy
     - pandas
     - psutil
     - requests
-    - shapely

--- a/docs/basic-usage.ipynb
+++ b/docs/basic-usage.ipynb
@@ -9,34 +9,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "9319e933",
-   "metadata": {
-    "tags": [
-     "remove-cell"
-    ]
-   },
-   "source": [
-    "## ~~Command line utility~~\n",
-    "\n",
-    "~~TODO~~"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0b7459d8",
-   "metadata": {
-    "tags": [
-     "remove-cell"
-    ]
-   },
-   "source": [
-    "```bash\n",
-    "$ # DOES NOT WORK YET r5py travel-time-matrix somewhere.osm.pbf somehwere_gtfs.zip --origins grid-centroids.gpkg ...\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "439ee015",

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -29,4 +29,5 @@ matplotlib
 numpy
 pandas
 psutil
+rasterio>=1.3a3
 shapely

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -26,6 +26,7 @@ geopandas
 joblib
 jpype1
 matplotlib
+numpy
 pandas
 psutil
-rasterio>=1.3a3
+shapely

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,14 +28,12 @@ package_dir =
 python_requires = >= 3.8
 install_requires =
     ConfigArgParse
-    geopandas
     joblib
     jpype1
     numpy
     pandas
     psutil
     requests
-    shapely
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
This addresses issue #52 - I cleaned the requirements.txt and environment.yml files, as well as the requirements of the documentation, to only depend on packages that we actually import. This meant taking geopandas and shapely off the general dependency lists, but adding a few packages to the dependencies of the documentation notebooks. 

(Note for future selves: if we want to introduce typehints at some point, we will need geopandas and shapely, again)