### PR TITLE
TransportNetwork as a context manager

### DIFF
--- a/src/r5py/r5/transport_network.py
+++ b/src/r5py/r5/transport_network.py
@@ -117,6 +117,14 @@ class TransportNetwork:
 
         return cls(osm_pbf, gtfs, build_json)
 
+    def __enter__(self):
+        """Provide a context."""
+        return self
+
+    def __exit__(self):
+        """Exit context."""
+        return False
+
     @property
     def linkage_cache(self):
         """Expose the `TransportNetwork`’s `linkageCache` to Python."""


### PR DESCRIPTION
This change allows TransportNetwork to be used as a context manager:

```
with TransportNetwork(path_to_osm, path_to_gtfs) as transport_network:
    travel_time_matrix = TravelTimeMatrixComputer(transport_network, ...).compute_travel_times()
    ...
```