### PR TITLE
Allow manually rebuilding main

### DIFF
--- a/.github/workflows/build-merged-pull-requests.yml
+++ b/.github/workflows/build-merged-pull-requests.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
     types: [closed]
   workflow_call:
+  workflow_dispatch:
 
 jobs:
 


### PR DESCRIPTION
The workflow/job to try to build the main branch does not trigger in the right moments, resulting in a build badge saying ‘failed’ on the front page. This adds a manual trigger to the build chain so we can run it on `main` without directly pushing to it.