### PR TITLE
Trigger main-rebuild on pull_request AND on push

### DIFF
--- a/.github/workflows/build-merged-pull-requests.yml
+++ b/.github/workflows/build-merged-pull-requests.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
     types: [closed]
   workflow_call:
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/build-merged-pull-requests.yml
+++ b/.github/workflows/build-merged-pull-requests.yml
@@ -6,11 +6,11 @@ on:
   pull_request:
     branches: [main]
     types: [closed]
+  push:
+    branches: [main]
   workflow_call:
-  workflow_dispatch:
 
 jobs:
-
   build:
     name: Build wheel(s) and packages
     runs-on: ubuntu-latest


### PR DESCRIPTION
This results in a build process being run on the main branch, and should fix the build badge not being updated (because the build badge does not take into account build happening during pull_requests - they are technically completed in the source branch). 

Closes #112 (hopefully)