### PR TITLE
fix tests on windows

### DIFF
--- a/.github/workflows/lint-test-upon-push.yml
+++ b/.github/workflows/lint-test-upon-push.yml
@@ -70,13 +70,6 @@ jobs:
           miniforge-version: latest
           use-mamba: true
 
-      - name: On Windows, resort JDK/GDAL conflicts
-        if: matrix.os == 'windows-latest'
-        run: mamba install --force-reinstall gdal libgdal libzip freetype
-
-      - name: Test whether fiona can be imported
-        run: python -c "import fiona"
-
       - name: Make sure pytest{,-cov,-lazy-fixture} are installed
         shell: bash -l {0}
         run: mamba install -c conda-forge pytest pytest-cov pytest-lazy-fixture

--- a/.github/workflows/lint-test-upon-push.yml
+++ b/.github/workflows/lint-test-upon-push.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         os: 
           - ubuntu-latest
-          # - windows-latest  # see issue #156
+          - windows-latest
           - macos-latest
         env:
           - ci/python_310.yaml

--- a/ci/python_310.yaml
+++ b/ci/python_310.yaml
@@ -6,6 +6,7 @@ channels:
 dependencies:
     - python=3.10
     - configargparse
+    - fiona
     - geopandas
     - joblib
     - jpype1

--- a/ci/python_310_dev.yaml
+++ b/ci/python_310_dev.yaml
@@ -6,6 +6,7 @@ channels:
 dependencies:
     - python=3.10
     - configargparse
+    - fiona
     - geopandas
     - joblib
     - jpype1

--- a/ci/python_38.yaml
+++ b/ci/python_38.yaml
@@ -6,6 +6,7 @@ channels:
 dependencies:
     - python=3.8
     - configargparse
+    - fiona
     - geopandas
     - joblib
     - jpype1

--- a/ci/python_39.yaml
+++ b/ci/python_39.yaml
@@ -6,6 +6,7 @@ channels:
 dependencies:
     - python=3.9
     - configargparse
+    - fiona
     - geopandas
     - joblib
     - jpype1

--- a/ci/r5py_distro.yaml
+++ b/ci/r5py_distro.yaml
@@ -6,6 +6,7 @@ channels:
 dependencies:
     - python=3.10
     - folium
+    - fiona
     - geopandas
     - matplotlib
     - mapclassify

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,8 @@
 
 import pathlib
 
+# explicitly importing fiona before geopandas fixes issue #156
+import fiona  # noqa: F401
 import geopandas
 import pytest  # noqa: F401
 


### PR DESCRIPTION
I might have figured out a way to fix issue #156. This works locally on my Windows VM, let’s see how far it goes on the GitHub runners. 

What I did was add an explicit import statement for `fiona` before `geopandas` in `conftest.py`. This does not yet fix the packaging issue with openjdk on conda-forge, but this is being dealt with upstream.

*EDIT:* The way I see it in retrospect, the issue was that geopandas attempted to import fiona from within a test case, which is isolated by pytest for good reasons. By importing fiona ahead of time, we avoid this problem. 