### PR TITLE
Fix routing for cars

### DIFF
--- a/src/r5py/r5/speed_config.py
+++ b/src/r5py/r5/speed_config.py
@@ -33,6 +33,7 @@ class SpeedConfig(dict):
             "tertiary_link": 25,
             "living_street": 5,
         },
+        "defaultSpeed": 40
     }
 
     def __init__(self, **kwargs):

--- a/src/r5py/r5/speed_config.py
+++ b/src/r5py/r5/speed_config.py
@@ -33,7 +33,7 @@ class SpeedConfig(dict):
             "tertiary_link": 25,
             "living_street": 5,
         },
-        "defaultSpeed": 40
+        "defaultSpeed": 40,
     }
 
     def __init__(self, **kwargs):

--- a/src/r5py/r5/speed_config.py
+++ b/src/r5py/r5/speed_config.py
@@ -33,7 +33,7 @@ class SpeedConfig(dict):
             "tertiary_link": 25,
             "living_street": 5,
         },
-        "defaultSpeed": 40,
+        "defaultSpeed": 25,
     }
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
Found the culprit, why routing for cars kept failing: the default speed for roads that have not set any road class and/or speed limit is not copied from the Java `SpeedConfig`. Setting it on the Python side makes things work as expected :)

closes #191 