### PR TITLE
Adding mapping of strings to modes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ docs/jupyter_execute/
 .tox
 .coverage
 coverage.xml
+.vscode/*

--- a/src/r5py/r5/regional_task.py
+++ b/src/r5py/r5/regional_task.py
@@ -13,6 +13,7 @@ from .scenario import Scenario
 from .street_mode import StreetMode
 from .transit_mode import TransitMode
 from ..util import start_jvm
+from ..util.modes import MODE_STRING_TO_ENUM
 
 import java.io
 import java.time
@@ -82,11 +83,11 @@ class RegionalTask:
             Return the travel time for these percentiles of all computed trips,
             by travel time. By default, return the median travel time.
             Default: [50]
-        transport_modes : list[r5py.TransitMode | r5py.LegMode]
-            The mode of transport to use for routing.
+        transport_modes : list[r5py.TransitMode | r5py.LegMode] or list[str]
+            The mode of transport to use for routing. Can be a r5py mode enumerable, or a string representation (e.g. "TRANSIT")
             Default: [r5py.TransitMode.TRANSIT] (all public transport)
-        access_modes : list[r5py.LegMode]
-            Mode of transport to public transport stops.
+        access_modes : list[r5py.LegMode] or list[str]
+            Mode of transport to public transport stops. Can be a r5py mode object, or a string representation (e.g. "WALK")
             Default: [r5py.LegMode.WALK]
         egress_modes : list[r5py.LegMode]
             Mode of transport from public transport stops.
@@ -186,6 +187,11 @@ class RegionalTask:
     @access_modes.setter
     def access_modes(self, access_modes):
         access_modes = set(access_modes)
+        # If they are strings, convert them to the correct ENUM using the provided utility
+        access_modes = {
+            MODE_STRING_TO_ENUM[mode] if isinstance(mode, str) else mode
+            for mode in access_modes
+        }
         self._access_modes = access_modes
         self._regional_task.accessModes = RegionalTask._enum_set(
             access_modes, com.conveyal.r5.api.util.LegMode
@@ -308,6 +314,11 @@ class RegionalTask:
     @egress_modes.setter
     def egress_modes(self, egress_modes):
         egress_modes = set(egress_modes)
+        # If they are strings, convert them to the correct ENUM using the provided utility
+        egress_modes = {
+            MODE_STRING_TO_ENUM[mode] if isinstance(mode, str) else mode
+            for mode in egress_modes
+        }
         self._egress_modes = egress_modes
         self._regional_task.egressModes = RegionalTask._enum_set(
             egress_modes, com.conveyal.r5.api.util.LegMode
@@ -479,6 +490,11 @@ class RegionalTask:
     @transport_modes.setter
     def transport_modes(self, transport_modes):
         transport_modes = set(transport_modes)
+        # Convert strings to enums as needed
+        transport_modes = {
+            MODE_STRING_TO_ENUM[mode] if isinstance(mode, str) else mode
+            for mode in transport_modes
+        }
         self._transport_modes = transport_modes
 
         # split them up into direct and transit modes,

--- a/src/r5py/util/modes.py
+++ b/src/r5py/util/modes.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+"""Conversion of mode strings to proper mode enums"""
+
+
+from ..r5.transit_mode import TransitMode
+from ..r5.leg_mode import LegMode
+
+
+MODE_STRING_TO_ENUM = {
+    "WALK": LegMode.WALK,
+    "BICYCLE": LegMode.BICYCLE,
+    "CAR": LegMode.CAR,
+    "AIR": TransitMode.AIR,
+    "TRAM": TransitMode.TRAM,
+    "SUBWAY": TransitMode.SUBWAY,
+    "RAIL": TransitMode.RAIL,
+    "BUS": TransitMode.BUS,
+    "FERRY": TransitMode.FERRY,
+    "CABLE_CAR": TransitMode.CABLE_CAR,
+    "GONDOLA": TransitMode.GONDOLA,
+    "FUNICULAR": TransitMode.FUNICULAR,
+    "TRANSIT": TransitMode.TRANSIT,
+    "BICYCLE_RENT": LegMode.BICYCLE_RENT,
+    "CAR_PARK": LegMode.CAR_PARK,
+}

--- a/tests/test_regional_task.py
+++ b/tests/test_regional_task.py
@@ -50,6 +50,40 @@ class TestRegionalTask:
         )
 
     @pytest.mark.parametrize(
+        ["access_modes", "expected"],
+        [
+            (
+                ["WALK"],
+                set([r5py.LegMode.WALK]),
+            ),
+            (
+                ["BICYCLE"],
+                set([r5py.LegMode.BICYCLE]),
+            ),
+            (
+                ["CAR"],
+                set([r5py.LegMode.CAR]),
+            ),
+            (
+                ["WALK", "BICYCLE"],
+                set([r5py.LegMode.WALK, r5py.LegMode.BICYCLE]),
+            ),
+            (
+                ["WALK", "BICYCLE", "CAR"],
+                set([r5py.LegMode.WALK, r5py.LegMode.BICYCLE, r5py.LegMode.CAR]),
+            ),
+        ],
+    )
+    def test_access_mode_setter_with_strings(
+        self, regional_task, access_modes, expected
+    ):
+        regional_task.access_modes = access_modes
+        assert regional_task.access_modes == expected
+        assert regional_task._regional_task.accessModes == r5py.RegionalTask._enum_set(
+            expected, com.conveyal.r5.api.util.LegMode
+        )
+
+    @pytest.mark.parametrize(
         [
             "departure",
             "expected",
@@ -77,6 +111,72 @@ class TestRegionalTask:
         assert regional_task.departure == expected
         assert regional_task._regional_task.date == expected_java_date
         assert regional_task._regional_task.fromTime == expected_java_from_time
+
+    @pytest.mark.parametrize(
+        ["egress_modes", "expected"],
+        [
+            (
+                [r5py.LegMode.WALK],
+                set([r5py.LegMode.WALK]),
+            ),
+            (
+                [r5py.LegMode.BICYCLE],
+                set([r5py.LegMode.BICYCLE]),
+            ),
+            (
+                [r5py.LegMode.CAR],
+                set([r5py.LegMode.CAR]),
+            ),
+            (
+                [r5py.LegMode.WALK, r5py.LegMode.BICYCLE],
+                set([r5py.LegMode.WALK, r5py.LegMode.BICYCLE]),
+            ),
+            (
+                [r5py.LegMode.WALK, r5py.LegMode.BICYCLE, r5py.LegMode.CAR],
+                set([r5py.LegMode.WALK, r5py.LegMode.BICYCLE, r5py.LegMode.CAR]),
+            ),
+        ],
+    )
+    def test_egress_mode_setter(self, regional_task, egress_modes, expected):
+        regional_task.egress_modes = egress_modes
+        assert regional_task.egress_modes == expected
+        assert regional_task._regional_task.egressModes == r5py.RegionalTask._enum_set(
+            expected, com.conveyal.r5.api.util.LegMode
+        )
+
+    @pytest.mark.parametrize(
+        ["egress_modes", "expected"],
+        [
+            (
+                ["WALK"],
+                set([r5py.LegMode.WALK]),
+            ),
+            (
+                ["BICYCLE"],
+                set([r5py.LegMode.BICYCLE]),
+            ),
+            (
+                ["CAR"],
+                set([r5py.LegMode.CAR]),
+            ),
+            (
+                ["WALK", "BICYCLE"],
+                set([r5py.LegMode.WALK, r5py.LegMode.BICYCLE]),
+            ),
+            (
+                ["WALK", "BICYCLE", "CAR"],
+                set([r5py.LegMode.WALK, r5py.LegMode.BICYCLE, r5py.LegMode.CAR]),
+            ),
+        ],
+    )
+    def test_egress_mode_setter_with_strings(
+        self, regional_task, egress_modes, expected
+    ):
+        regional_task.egress_modes = egress_modes
+        assert regional_task.egress_modes == expected
+        assert regional_task._regional_task.egressModes == r5py.RegionalTask._enum_set(
+            expected, com.conveyal.r5.api.util.LegMode
+        )
 
     @pytest.mark.parametrize(
         ["bicycle_stress", "expected"],
@@ -339,5 +439,28 @@ class TestRegionalTask:
     def test_origin_setter_getter(self, regional_task, origin):
         regional_task.origin = origin
         assert regional_task.origin == origin
+
+    @pytest.mark.parametrize(
+        ["transport_modes", "expected"],
+        [
+            (
+                ["WALK"],
+                set([r5py.LegMode.WALK]),
+            ),
+            (
+                ["TRANSIT", "WALK"],
+                set([r5py.TransitMode.TRANSIT, r5py.LegMode.WALK]),
+            ),
+            (
+                ["GONDOLA", "SUBWAY"],
+                set([r5py.TransitMode.GONDOLA, r5py.TransitMode.SUBWAY]),
+            ),
+        ],
+    )
+    def test_transport_modes_setter_with_strings(
+        self, regional_task, transport_modes, expected
+    ):
+        regional_task.transport_modes = transport_modes
+        assert regional_task.transport_modes == expected
 
     # TODO: all other methods and attributes!


### PR DESCRIPTION
See issue #265.

Also added: tests for string versions of `access_mode`, `egress_mode`, and `transport_mode` specifications

The setters for the various modes now do a quick set comprehension to convert strings into proper enum types using a dictionary added in the `utils` section. Figured that would be the best place for it.