### PR TITLE
[WIP] Added agency and stop info to detailed itineraries

### DIFF
--- a/src/r5py/r5/detailed_itineraries_computer.py
+++ b/src/r5py/r5/detailed_itineraries_computer.py
@@ -114,15 +114,18 @@ class DetailedItinerariesComputer(BaseTravelTimeMatrixComputer):
         -------
         geopandas.GeoDataFrame
             The resulting detailed routes. For each origin/destination pair,
-            multiple route alternatives (‘options’) might be reported that each consist of
-            one or more segments. Each segment represents one row.
+            multiple route alternatives (‘options’) might be reported that each
+            consist of one or more segments. Each segment represents one row.
             The data frame comprises of the following columns: `from_id`,
             `to_id`, `option` (`int`), `segment` (`int`), `transport_mode`
             (`r5py.TransportMode`), `departure_time` (`datetime.datetime`),
             `distance` (`float`, metres), `travel_time` (`datetime.timedelta`),
-            `wait_time` (`datetime.timedelta`), `route` (`str`, public transport
-            route number or name), `geometry` (`shapely.LineString`)
-            TODO: Add description of output data frame columns and format
+            `wait_time` (`datetime.timedelta`), `feed` (`str`, the feed name
+            used), `agency_id` (`str` the public transport agency identifier),
+            `route_id` (`str`, public transport route ID), `start_stop_id`
+            (`str`, the GTFS stop_id for boarding), `end_stop_id` (`str`, the
+            GTFS stop_id for alighting), `geometry` (`shapely.LineString`) TODO:
+            Add description of output data frame columns and format
         """
 
         self._prepare_origins_destinations()

--- a/src/r5py/r5/transit_layer.py
+++ b/src/r5py/r5/transit_layer.py
@@ -73,7 +73,7 @@ class TransitLayer:
 
     def get_street_vertex_for_stop(self, stop):
         """
-        Get the street layer’s vertex corresponding to `stop`.
+        Get the street layer's vertex corresponding to `stop`.
 
         Arguments
         ---------
@@ -95,6 +95,9 @@ class TransitLayer:
     @functools.cached_property
     def trip_patterns(self):
         return list(self._transit_layer.tripPatterns)
+
+    def get_stop_id_from_index(self, stop_index):
+        return self._transit_layer.stopIdForIndex[stop_index]
 
 
 @jpype._jcustomizer.JConversion(

--- a/src/r5py/r5/trip.py
+++ b/src/r5py/r5/trip.py
@@ -45,15 +45,20 @@ class Trip:
 
     def as_table(self):
         """
-        Return a table (list of lists) of this trip’s legs.
+        Return a table (list of lists) of this trip's legs.
 
         Returns
         =======
         list : detailed information about this trip and its legs (segments):
         ``segment``, ``transport_mode``, ``departure_time``, ``distance``,
-        ``travel_time``, ``wait_time``, ``route``, ``geometry``
+        ``travel_time``, ``wait_time``, ``feed``, ``agency_id``, ``route_id``, ``start_stop_id``, ``end_stop_id``, ``geometry``
         """
         return [[segment] + leg.as_table_row() for segment, leg in enumerate(self.legs)]
+
+    @property
+    def agency_ids(self):
+        """The public transport agency name(s) used on this trip."""
+        return [leg.agency_id for leg in self.legs]
 
     @property
     def distance(self):
@@ -72,9 +77,9 @@ class Trip:
         )
 
     @property
-    def routes(self):
+    def route_ids(self):
         """The public transport route(s) used on this trip."""
-        return [leg.route for leg in self.legs]
+        return [leg.route_id for leg in self.legs]
 
     @property
     def transport_modes(self):

--- a/src/r5py/r5/trip_leg.py
+++ b/src/r5py/r5/trip_leg.py
@@ -21,7 +21,11 @@ class TripLeg:
         "distance",
         "travel_time",
         "wait_time",
-        "route",
+        "feed",
+        "agency_id",
+        "route_id",
+        "start_stop_id",
+        "end_stop_id",
         "geometry",
     ]
 
@@ -32,28 +36,39 @@ class TripLeg:
         distance=None,
         travel_time=None,
         wait_time=None,
-        route=None,
+        feed=None,
+        agency_id=None,
+        route_id=None,
+        start_stop_id=None,
+        end_stop_id=None,
         geometry=None,
     ):
         """
         Represent one leg of a trip.
 
-        This is a base class, use one the specific classes,
-        e.g., TransitLeg, or DirectLeg
+        This is a base class, use one the specific classes, e.g., TransitLeg, or
+        DirectLeg
 
         Arguments
         =========
         transport_mode : r5py.TransportMode
             mode of transport this trip leg was travelled
-        departure_time : datetime.datetime,
-        distance : float
+        departure_time : datetime.datetime, distance : float
             distance covered by this trip leg, in metres
         travel_time : datetime.timedelta
             time spent travelling on this trip leg
         wait_time : datetime.timedelta
             time spent waiting for a connection on this trip leg
-        route : str
-            public transport route used for this trip leg
+        feed : str
+            the GTFS feed identifier used for this trip leg
+        agency_id : str
+            the GTFS id the agency used for this trip leg
+        route_id : str
+            the GTFS id of the public transport route used for this trip leg
+        start_stop_id : str
+            the GTFS stop_id of the boarding stop used for this trip leg
+        end_stop_id : str
+            the GTFS stop_id of the aligning stop used for this trip leg
         geometry : shapely.LineString
             spatial representation of this trip leg
         """
@@ -62,7 +77,11 @@ class TripLeg:
         self.distance = distance
         self.travel_time = travel_time
         self.wait_time = wait_time
-        self.route = route
+        self.feed = feed
+        self.agency_id = agency_id
+        self.route_id = route_id
+        self.start_stop_id = start_stop_id
+        self.end_stop_id = end_stop_id
         self.geometry = geometry
 
     def __add__(self, other):
@@ -138,7 +157,7 @@ class TripLeg:
         Returns
         =======
         list : detailed information about this trip leg: ``transport_mode``,
-        ``departure_time``, ``distance``, ``travel_time``, ``wait_time``,
-        ``route``, ``geometry``
+        ``departure_time``, ``distance``, ``travel_time``, ``wait_time``, ``feed``, ``agency_id``
+        ``route_id``, ``start_stop_id``, ``end_stop_id``, ``geometry``
         """
         return [getattr(self, column) for column in self.COLUMNS]

--- a/src/r5py/r5/trip_planner.py
+++ b/src/r5py/r5/trip_planner.py
@@ -195,7 +195,6 @@ class TripPlanner:
                                 distance=0.0,
                                 travel_time=ZERO_SECONDS,
                                 wait_time=ZERO_SECONDS,
-                                route=None,
                                 geometry=shapely.LineString(((lon, lat), (lon, lat))),
                             )
                         ]
@@ -294,6 +293,17 @@ class TripPlanner:
 
                             else:  # TransitLeg
                                 pattern = transit_layer.trip_patterns[state.pattern]
+
+                                # Use the indices to look up the stop ids, which are scoped by the GTFS feed supplied
+                                start_stop_id = transit_layer.get_stop_id_from_index(
+                                    state.back.stop
+                                ).split(":")[1]
+                                end_stop = transit_layer.get_stop_id_from_index(
+                                    state.stop
+                                )
+                                end_stop_id = end_stop.split(":")[1]
+                                feed = end_stop.split(":")[0]
+
                                 route = transit_layer.routes[pattern.routeIndex]
                                 transport_mode = TransportMode(
                                     com.conveyal.r5.transit.TransitLayer.getTransitModes(
@@ -346,13 +356,17 @@ class TripPlanner:
                                     distance = None
 
                                 leg = TransitLeg(
-                                    transport_mode,
-                                    departure_time,
-                                    distance,
-                                    travel_time,
-                                    wait_time,
-                                    str(route.route_short_name),
-                                    geometry,
+                                    transport_mode=transport_mode,
+                                    departure_time=departure_time,
+                                    distance=distance,
+                                    travel_time=travel_time,
+                                    wait_time=wait_time,
+                                    feed=str(feed),
+                                    agency_id=str(route.agency_id),
+                                    route_id=str(route.route_id),
+                                    start_stop_id=str(start_stop_id),
+                                    end_stop_id=str(end_stop_id),
+                                    geometry=geometry,
                                 )
 
                         # we traverse in reverse order:


### PR DESCRIPTION
This PR adds more detail to the transit portions of the detailed itineraries.

The main thing left to do here is generate the updated data column. @christophfink how did you go about that? It looks like a lot of the data is trimmed in a certain way; do you have a pattern for regenerating the test data?