### PR TITLE
v1.0.2: include *all* test files in sdist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- **1.0.2** (2025-03-13):
+    - Include test fixtures and data in sdist
+
 - **1.0.1** (2025-03-11):
     - Added typing-extensions to dependencies
     - Optimised binder integration and environment

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include tests *.py
+recursive-include tests/data *
+global-exclude *.pyc

--- a/src/r5py/__init__.py
+++ b/src/r5py/__init__.py
@@ -2,7 +2,7 @@
 
 """Python wrapper for the R5 routing analysis engine."""
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 
 from .r5 import (


### PR DESCRIPTION
Until now, only some unit test files where included in the sdist. For instance, fixtures (conftest.py) where omitted, rendering all test files useless. This includes all test files, so repackagers can run tests