### PR TITLE
Add default permissions for all workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ name: Lint code
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Linting code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
       - v*.*.*.dev*
       - v*.*.*.post*
 
+permissions:
+  contents: read
+
 jobs:
   test:
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Description

Please provide a brief summary of the changes included in this pull request:

- What is the goal of this PR?
  GitHub now encourages to set the permissions for workflows explicitly, even if they are the default values

- What parts of the codebase does it affect?
  The workflow definitions

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Documentation update
- [ ] Refactoring
- [ ] Tests
- [x] CI/CD improvement

## Checklist

Please check off the items you completed before requesting a review:

- [x] I have read the [CONTRIBUTING
  guide](https://r5py.readthedocs.io/en/stable/contributing/CONTRIBUTING.html).
- [x] I have rebased/merged the latest changes from `main`.
- [ ] I have verified that CI passes after my changes.