### PR TITLE
remove deprecation warning

### DIFF
--- a/tests/conftest_d/__init__.py
+++ b/tests/conftest_d/__init__.py
@@ -3,18 +3,6 @@
 
 """Fixtures to be used in r5py tests."""
 
-# geopandas 1.0.1 imports shapely.geos which raises
-# a Deprecation warning in Shapely 2.1.0
-import warnings
-
-with warnings.catch_warnings():
-    warnings.filterwarnings(
-        "ignore",
-        category=DeprecationWarning,
-        message=".*shapely.geos.*deprecated.*",
-    )
-    import geopandas  # noqa: F401
-
 
 from .destinations import (
     population_grid,


### PR DESCRIPTION
## Description

Please provide a brief summary of the changes included in this pull request:

- What is the goal of this PR?
- What parts of the codebase does it affect?

Previously, importing `geopandas` would raise a `DeprecationWarning` from `shapely.geos` as the latter‘s newest release had deprecated features the former uses.
Affects the test suite

Fixes #477 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Documentation update
- [ ] Refactoring
- [x] Tests
- [ ] CI/CD improvement

## Checklist

Please check off the items you completed before requesting a review:

- [x] I have read the [CONTRIBUTING
  guide](https://r5py.readthedocs.io/en/stable/contributing/CONTRIBUTING.html).
- [x] I have formatted my code with `black` and ensured linting passes
  (`flake8`).
- [x] I have made sure my code follows the style guidelines of this project.
- [x] I have rebased/merged the latest changes from `main`.
- [ ] I have verified that CI passes after my changes.
