### PR TITLE
exclude unreachable lines from coverage tests

### DIFF
--- a/src/r5py/util/environment.py
+++ b/src/r5py/util/environment.py
@@ -20,15 +20,15 @@ if (
     "CONDA_PREFIX" not in os.environ
     and "CONDA_DEFAULT_ENV" in os.environ
     and "CONDA_ENVS_PATH" in os.environ
-):  # pragma: no-cover
+):  # pragma: no cover
     os.environ["CONDA_PREFIX"] = str(
         pathlib.Path(os.environ["CONDA_ENVS_PATH"]) / os.environ["CONDA_DEFAULT_ENV"]
     )
-if "JAVA_HOME" not in os.environ and "CONDA_PREFIX" in os.environ:  # pragma: no-cover
+if "JAVA_HOME" not in os.environ and "CONDA_PREFIX" in os.environ:  # pragma: no cover
     os.environ["JAVA_HOME"] = str(
         pathlib.Path(os.environ["CONDA_PREFIX"]) / "lib" / "jvm"
     )
-if "PROJ_LIB" not in os.environ and "CONDA_PREFIX" in os.environ:  # pragma: no-cover
+if "PROJ_LIB" not in os.environ and "CONDA_PREFIX" in os.environ:  # pragma: no cover
     os.environ["PROJ_LIB"] = str(
         pathlib.Path(os.environ["CONDA_PREFIX"]) / "share" / "proj"
     )

--- a/src/r5py/util/jvm.py
+++ b/src/r5py/util/jvm.py
@@ -35,13 +35,13 @@ def start_jvm():
             try:
                 LIBJSIG = next(JVM_PATH.parent.glob("**/libjsig.so"))
                 os.environ["LD_PRELOAD"] = str(LIBJSIG)
-            except StopIteration:  # pragma: no-cover
+            except StopIteration:  # pragma: no cover
                 pass  # don’t fail completely if libjsig not found
         elif sys.platform == "darwin":
             try:
                 LIBJSIG = next(JVM_PATH.parent.glob("**/libjsig.dylib"))
                 os.environ["DYLD_INSERT_LIBRARIES"] = str(LIBJSIG)
-            except StopIteration:  # pragma: no-cover
+            except StopIteration:  # pragma: no cover
                 pass  # don’t fail completely if libjsig not found
 
         TEMP_DIR = Config().TEMP_DIR
@@ -63,7 +63,7 @@ def start_jvm():
         @jpype.JImplements("java.lang.Runnable")
         class ShutdownHookToCleanUpTempDir:
             @jpype.JOverride
-            def run(self):  # pragma: no-cover
+            def run(self):  # pragma: no cover
                 shutil.rmtree(TEMP_DIR)
 
         import java.lang


### PR DESCRIPTION
## Description

Please provide a brief summary of the changes included in this pull request:

- _What is the goal of this PR?_ To exclude lines from coverage reports that cannot be reached in normal configurations (but are failsafe workarounds or there for logical balance)

- _What parts of the codebase does it affect?_ `r5py.util.jvm`, `r5py.util.environment`

## Checklist

Please check off the items you completed before requesting a review:

- [x] I have read the [CONTRIBUTING
  guide](https://r5py.readthedocs.io/en/stable/contributing/CONTRIBUTING.html).
- [x] I have added tests that prove my fix is effective or that my feature
  works.
- [x] I have added or updated documentation where necessary, and ensured it
  fulfills the `pydocstyle` standards.
- [x] I have formatted my code with `black` and ensured linting passes
  (`flake8`).
- [x] I have made sure my code follows the style guidelines of this project.
- [x] I have rebased/merged the latest changes from `main`.
- [ ] I have verified that CI passes after my changes.
