### PR TITLE
allow remote data sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ docs/jupyter_execute/
 docs/user-guide/user-manual/travel_times_to_helsinki_railway_station.csv
 docs/user-guide/user-manual/detailed_itineraries.gpkg
 
+paper-case-studies
+
 .tox
 .coverage
 coverage.xml

--- a/src/r5py/util/classpath.py
+++ b/src/r5py/util/classpath.py
@@ -78,7 +78,7 @@ def find_r5_classpath(arguments):
                 )
             with (
                 ValidatingRequestsSession() as session,
-                session.get(R5_JAR_URL, R5_JAR_SHA256) as response,
+                session.get(R5_JAR_URL, checksum=R5_JAR_SHA256) as response,
                 open(r5_classpath, "wb") as jar,
             ):
                 jar.write(response.content)

--- a/src/r5py/util/jvm.py
+++ b/src/r5py/util/jvm.py
@@ -41,7 +41,6 @@ def start_jvm():
                 LIBJSIG = next(JVM_PATH.parent.glob("**/libjsig.dylib"))
                 os.environ["DYLD_INSERT_LIBRARIES"] = str(LIBJSIG)
             except StopIteration:  # pragma: no cover
-                print(f"No DYLD found in {JVM_PATH.parent}")
                 pass  # don’t fail completely if libjsig not found
 
         TEMP_DIR = Config().TEMP_DIR

--- a/src/r5py/util/jvm.py
+++ b/src/r5py/util/jvm.py
@@ -41,6 +41,7 @@ def start_jvm():
                 LIBJSIG = next(JVM_PATH.parent.glob("**/libjsig.dylib"))
                 os.environ["DYLD_INSERT_LIBRARIES"] = str(LIBJSIG)
             except StopIteration:  # pragma: no cover
+                print(f"No DYLD found in {JVM_PATH.parent}")
                 pass  # don’t fail completely if libjsig not found
 
         TEMP_DIR = Config().TEMP_DIR

--- a/src/r5py/util/remote_file.py
+++ b/src/r5py/util/remote_file.py
@@ -3,6 +3,7 @@
 
 """A remote data set that is downloaded on demand."""
 
+import datetime
 import hashlib
 import pathlib
 import warnings
@@ -13,6 +14,8 @@ from .config import Config
 from .validating_requests_session import ValidatingRequestsSession
 
 config = Config()
+
+ONE_DAY = datetime.timedelta(days=1)
 
 
 class RemoteFile(pathlib.Path):
@@ -33,7 +36,7 @@ class RemoteFile(pathlib.Path):
         cached_path = cls._CACHE_DIR / pathlib.Path(remote_url).name
         return super().__new__(cls, cached_path)
 
-    def __init__(self, remote_url, sha256_checksum=None):
+    def __init__(self, remote_url, sha256_checksum=None, max_cache_age=ONE_DAY):
         """
         Define a data set that is downloaded and cached on demand.
 
@@ -54,6 +57,7 @@ class RemoteFile(pathlib.Path):
         self.remote_url = remote_url
         self.checksum = sha256_checksum
         self.cached_path = cached_path
+        self.max_cache_age = max_cache_age
         self._download_remote_file()
 
     def _download_remote_file(self):
@@ -80,6 +84,9 @@ class RemoteFile(pathlib.Path):
                         stacklevel=1,
                     )
                 raise exception
+            assert datetime.datetime.fromtimestamp(self.cached_path.stat().st_mtime) > (
+                datetime.datetime.now() - self.max_cache_age
+            )
         except (AssertionError, FileNotFoundError):
             self.cached_path.parent.mkdir(exist_ok=True)
             if self.checksum is not None:

--- a/src/r5py/util/remote_file.py
+++ b/src/r5py/util/remote_file.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+
+"""A remote data set that is downloaded on demand."""
+
+import hashlib
+import pathlib
+import warnings
+
+import requests
+
+from .config import Config
+from .validating_requests_session import ValidatingRequestsSession
+
+config = Config()
+
+
+class RemoteFile(pathlib.Path):
+    """Data set that is downloaded and cached as needed."""
+
+    # decide which kind of pathlib.Path we are (Windows, Unix, ...)
+    # cf. https://stackoverflow.com/a/66613346/463864
+    try:
+        _flavour = type(pathlib.Path())._flavour  # pylint: disable=protected-access
+    except AttributeError:  # Python>=3.13
+        pass
+
+    _CACHE_DIR = pathlib.Path(config.CACHE_DIR) / "remote"
+
+    def __new__(cls, remote_url, sha256_checksum=None):
+        """Define a data set that is downloaded and cached on demand."""
+        # pathlib.Path does everything in __new__, rather than __init__
+        cached_path = cls._CACHE_DIR / pathlib.Path(remote_url).name
+        return super().__new__(cls, cached_path)
+
+    def __init__(self, remote_url, sha256_checksum=None):
+        """
+        Define a data set that is downloaded and cached on demand.
+
+        Arguments
+        ---------
+        remote_url : str
+            source URL for this data set
+        sha256_checksum : str
+            checksum for this data set, using an SHA256 algorithm
+        """
+        cached_path = self._CACHE_DIR / pathlib.Path(remote_url).name
+
+        try:  # Python>=3.12
+            super().__init__(cached_path)
+        except TypeError:
+            super().__init__()
+
+        self.remote_url = remote_url
+        self.checksum = sha256_checksum
+        self.cached_path = cached_path
+        self._download_remote_file()
+
+    def _download_remote_file(self):
+        try:
+            try:
+                checksum = hashlib.sha256(self.cached_path.read_bytes()).hexdigest()
+                if self.checksum is not None:
+                    assert checksum == self.checksum
+            except FileNotFoundError as exception:
+                if config.arguments.verbose:
+                    warnings.warn(
+                        f"First access to {pathlib.Path(self.remote_url).name}, "
+                        "downloading remote file to local cache",
+                        RuntimeWarning,
+                        stacklevel=1,
+                    )
+                raise exception
+            except AssertionError as exception:
+                if config.arguments.verbose:
+                    warnings.warn(
+                        f"{pathlib.Path(self.remote_url).name} changed, "
+                        "re-downloading remote file to local cache",
+                        RuntimeWarning,
+                        stacklevel=1,
+                    )
+                raise exception
+        except (AssertionError, FileNotFoundError):
+            self.cached_path.parent.mkdir(exist_ok=True)
+            if self.checksum is not None:
+                with (
+                    ValidatingRequestsSession() as session,
+                    session.get(self.remote_url, checksum=self.checksum) as response,
+                ):
+                    self.cached_path.write_bytes(response.content)
+            else:
+                with (
+                    requests.Session() as session,
+                    session.get(self.remote_url) as response,
+                ):
+                    self.cached_path.write_bytes(response.content)

--- a/src/r5py/util/sample_data_set.py
+++ b/src/r5py/util/sample_data_set.py
@@ -1,76 +1,17 @@
 #!/usr/bin/env python3
 
 
-"""A remote data set that is downloaded on demand."""
+"""A remote sample data set that is downloaded on demand."""
 
-import hashlib
 import pathlib
-import warnings
 
 from .config import Config
-from .validating_requests_session import ValidatingRequestsSession
+from .remote_file import RemoteFile
 
 config = Config()
 
 
-class SampleDataSet(pathlib.Path):
+class SampleDataSet(RemoteFile):
     """Data set that is downloaded and cached as needed."""
 
-    # decide which kind of pathlib.Path we are (Windows, Unix, ...)
-    # cf. https://stackoverflow.com/a/66613346/463864
-    try:
-        _flavour = type(pathlib.Path())._flavour
-    except AttributeError:  # Python>=3.13
-        pass
-
     _CACHE_DIR = pathlib.Path(config.CACHE_DIR) / "sampledata"
-
-    def __new__(cls, remote_url, sha256_checksum):
-        """Define a data set that is downloaded and cached on demand."""
-        # pathlib.Path does everything in __new__, rather than __init__
-        cached_path = cls._CACHE_DIR / pathlib.Path(remote_url).name
-        return super().__new__(cls, cached_path)
-
-    def __init__(self, remote_url, sha256_checksum, *args, **kwargs):
-        """
-        Define a data set that is downloaded and cached on demand.
-
-        Arguments
-        ---------
-        remote_url : str
-            source URL for this data set
-        sha256_checksum : str
-            checksum for this data set, using an SHA256 algorithm
-        """
-        cached_path = self._CACHE_DIR / pathlib.Path(remote_url).name
-
-        try:  # Python>=3.12
-            super().__init__(cached_path)
-        except TypeError:
-            super().__init__()
-
-        self.remote_url = remote_url
-        self.checksum = sha256_checksum
-        self.cached_path = cached_path
-        self._download_remote_file()
-
-    def _download_remote_file(self):
-        try:
-            assert (
-                hashlib.sha256(self.cached_path.read_bytes()).hexdigest()
-                == self.checksum
-            )
-        except (AssertionError, FileNotFoundError):
-            if config.arguments.verbose:
-                warnings.warn(
-                    f"First access to {pathlib.Path(self.remote_url).name}, "
-                    "downloading remote file to local cache",
-                    RuntimeWarning,
-                    stacklevel=1,
-                )
-            self.cached_path.parent.mkdir(exist_ok=True)
-            with (
-                ValidatingRequestsSession() as session,
-                session.get(self.remote_url, self.checksum) as response,
-            ):
-                self.cached_path.write_bytes(response.content)

--- a/src/r5py/util/validating_requests_session.py
+++ b/src/r5py/util/validating_requests_session.py
@@ -29,30 +29,30 @@ class ValidatingRequestsSession(requests.Session):
         super().__init__(*args, **kwargs)
         self._algorithm = checksum_algorithm
 
-    def get(self, url, checksum, **kwargs):
+    def get(self, *args, checksum=None, **kwargs):
         """Send a GET request, tests checksum."""
         kwargs.setdefault("allow_redirects", True)
-        return self.request("GET", url, checksum, **kwargs)
+        return self.request("GET", *args, checksum=checksum, **kwargs)
 
-    def post(self, url, checksum, **kwargs):
+    def post(self, *args, checksum=None, **kwargs):
         """Send a POST request, tests checksum."""
-        return self.request("POST", url, checksum, **kwargs)
+        return self.request("POST", *args, checksum=checksum, **kwargs)
 
     # delete, put, head don’t return data,
     # testing checksums does not apply
 
-    def request(self, method, url, checksum, **kwargs):
+    def request(self, *args, checksum=None, **kwargs):
         """
         Retrieve file from cache or proxy requests.request.
 
         Raise `ChecksumFailed` if the file’s digest and `checksum` differ.
         """
-        response = super().request(method, url, **kwargs)
+        response = super().request(*args, **kwargs)
         digest = self._algorithm(response.content).hexdigest()
 
         if digest != checksum:
             raise ChecksumFailed(
-                f"Checksum failed for {url}, expected {checksum}, got {digest}"
+                f"Checksum failed for {args[1]}, expected {checksum}, got {digest}"
             )
 
         return response

--- a/src/r5py/util/working_copy.py
+++ b/src/r5py/util/working_copy.py
@@ -2,11 +2,14 @@
 
 """Create a copy or link of an input file in a cache directory."""
 
-import filelock
 import pathlib
 import shutil
+import urllib.parse
+
+import filelock
 
 from .config import Config
+from .remote_file import RemoteFile
 
 __all__ = ["WorkingCopy"]
 
@@ -26,8 +29,17 @@ class WorkingCopy(pathlib.Path):
         Arguments
         ---------
         path : str or pathlib.Path
-            The file to create a copy or link of in a cache directory
+            The file to create a copy or link of in a cache directory. Can be a
+            URL with a schema of `https://`, `http://`, or `file://`
         """
+        if isinstance(path, str):  # test whether URL
+            scheme, netloc, urlpath, *_ = urllib.parse.urlsplit(path)
+            if netloc != "":
+                if scheme == "file":
+                    path = urlpath
+                elif scheme in ("https", "http"):
+                    path = RemoteFile(path)
+
         # try to first create a symbolic link, if that fails (e.g., on Windows),
         # copy the file to a cache directory
         path = pathlib.Path(path).absolute()

--- a/tests/test_remote_file.py
+++ b/tests/test_remote_file.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 
+import datetime
+import os
 import pathlib
 import sys
 
@@ -106,3 +108,17 @@ class TestRemoteFile:
         data_set = RemoteFile(sample_data_set_url, sample_data_set_sha256)
         assert data_set.exists()
         data_set.unlink()
+
+    def test_expired_remote_file(self, sample_data_set_url):
+        remote_file = RemoteFile(sample_data_set_url)
+        EXPIRED = (
+            datetime.datetime.now()
+            - remote_file.max_cache_age
+            - datetime.timedelta(days=1)
+        ).timestamp()
+        os.utime(remote_file, (EXPIRED, EXPIRED))
+
+        del remote_file
+
+        remote_file = RemoteFile(sample_data_set_url)
+        assert remote_file.stat().st_mtime > EXPIRED

--- a/tests/test_remote_file.py
+++ b/tests/test_remote_file.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+
+import pathlib
+import sys
+
+import pytest
+
+from r5py.util.config import Config
+from r5py.util.remote_file import RemoteFile
+
+
+class TestRemoteFile:
+    def test_data_set_with_verbose(self, sample_data_set_url, sample_data_set_sha256):
+        sys.argv.extend(
+            [
+                "--verbose",
+            ]
+        )
+
+        # make sure the cached file does not exist
+        try:
+            (
+                pathlib.Path(Config().CACHE_DIR)
+                / "remote"
+                / pathlib.Path(sample_data_set_url).name
+            ).unlink()
+        except FileNotFoundError:
+            pass
+
+        with pytest.warns(
+            RuntimeWarning,
+            match="First access to .*, downloading remote file to local cache",
+        ):
+            data_set = RemoteFile(sample_data_set_url, sample_data_set_sha256)
+            assert data_set.exists()
+
+        data_set.unlink()
+        sys.argv = sys.argv[:-1]
+
+    def test_data_set_with_verbose_without_checksum(self, sample_data_set_url):
+        sys.argv.extend(
+            [
+                "--verbose",
+            ]
+        )
+
+        # make sure the cached file does not exist
+        try:
+            (
+                pathlib.Path(Config().CACHE_DIR)
+                / "remote"
+                / pathlib.Path(sample_data_set_url).name
+            ).unlink()
+        except FileNotFoundError:
+            pass
+
+        with pytest.warns(
+            RuntimeWarning,
+            match="First access to .*, downloading remote file to local cache",
+        ):
+            data_set = RemoteFile(sample_data_set_url)
+            assert data_set.exists()
+
+        data_set.unlink()
+        sys.argv = sys.argv[:-1]
+
+    def test_data_set_with_verbose_with_corruption(
+        self, sample_data_set_url, sample_data_set_sha256
+    ):
+        sys.argv.extend(
+            [
+                "--verbose",
+            ]
+        )
+
+        # make sure the cached file does not exist
+        (pathlib.Path(Config().CACHE_DIR) / "remote").mkdir(parents=True, exist_ok=True)
+        (
+            pathlib.Path(Config().CACHE_DIR)
+            / "remote"
+            / pathlib.Path(sample_data_set_url).name
+        ).write_text("CORRUPTED CONTENT OF SAMPLE DATA SET")
+
+        with pytest.warns(
+            RuntimeWarning,
+            match=".* changed, re-downloading remote file to local cache",
+        ):
+            data_set = RemoteFile(sample_data_set_url, sample_data_set_sha256)
+            assert data_set.exists()
+
+        data_set.unlink()
+        sys.argv = sys.argv[:-1]
+
+    def test_data_set(self, sample_data_set_url, sample_data_set_sha256):
+        data_set = RemoteFile(sample_data_set_url, sample_data_set_sha256)
+        assert data_set.exists()
+        data_set.unlink()
+
+    def test_data_set_invalid_hash(self, sample_data_set_url, sample_data_set_sha256):
+        data_set = RemoteFile(sample_data_set_url, sample_data_set_sha256)
+        data_set.write_text("foobar")  # change file, invalidate checksum
+        del data_set
+
+        # try again:
+        data_set = RemoteFile(sample_data_set_url, sample_data_set_sha256)
+        assert data_set.exists()
+        data_set.unlink()

--- a/tests/test_validating_request_session.py
+++ b/tests/test_validating_request_session.py
@@ -19,7 +19,7 @@ class TestValidatingRequestSession:
     def test_get(self, r5_jar_url, r5_jar_sha256):
         with (
             ValidatingRequestsSession() as session,
-            session.get(r5_jar_url, r5_jar_sha256) as response,
+            session.get(r5_jar_url, checksum=r5_jar_sha256) as response,
         ):
             assert response.content
 
@@ -27,7 +27,7 @@ class TestValidatingRequestSession:
         with pytest.raises(ChecksumFailed):
             with (
                 ValidatingRequestsSession() as session,
-                session.get(r5_jar_url, r5_jar_sha256_invalid) as response,
+                session.get(r5_jar_url, checksum=r5_jar_sha256_invalid) as response,
             ):
                 assert response.content
 
@@ -35,7 +35,7 @@ class TestValidatingRequestSession:
         with (
             ValidatingRequestsSession() as session,
             session.post(
-                r5_jar_url, r5_jar_sha256_github_error_message_when_posting
+                r5_jar_url, checksum=r5_jar_sha256_github_error_message_when_posting
             ) as response,
         ):
             assert response.content
@@ -44,6 +44,6 @@ class TestValidatingRequestSession:
         with pytest.raises(ChecksumFailed):
             with (
                 ValidatingRequestsSession() as session,
-                session.post(r5_jar_url, r5_jar_sha256_invalid) as response,
+                session.post(r5_jar_url, checksum=r5_jar_sha256_invalid) as response,
             ):
                 assert response.content

--- a/tests/test_working_copy.py
+++ b/tests/test_working_copy.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+
+import pathlib
+
+from r5py.util.config import Config
+from r5py.util.sample_data_set import SampleDataSet
+from r5py.util.working_copy import WorkingCopy
+
+
+class TestWorkingCopy:
+    def test_working_copy_with_https_url(self, sample_data_set_url):
+        working_copy = WorkingCopy(sample_data_set_url)
+        assert pathlib.Path(Config().CACHE_DIR / working_copy.name).exists()
+
+    def test_working_copy_with_file_url(self, sample_data_set_url, sample_data_set_sha256):
+        sample_data_set = SampleDataSet(sample_data_set_url, sample_data_set_sha256)
+        working_copy = WorkingCopy(f"file://{sample_data_set}")
+        assert pathlib.Path(Config().CACHE_DIR / working_copy.name).exists()

--- a/tests/test_working_copy.py
+++ b/tests/test_working_copy.py
@@ -13,7 +13,9 @@ class TestWorkingCopy:
         working_copy = WorkingCopy(sample_data_set_url)
         assert pathlib.Path(Config().CACHE_DIR / working_copy.name).exists()
 
-    def test_working_copy_with_file_url(self, sample_data_set_url, sample_data_set_sha256):
+    def test_working_copy_with_file_url(
+        self, sample_data_set_url, sample_data_set_sha256
+    ):
         sample_data_set = SampleDataSet(sample_data_set_url, sample_data_set_sha256)
         working_copy = WorkingCopy(f"file://{sample_data_set}")
         assert pathlib.Path(Config().CACHE_DIR / working_copy.name).exists()


### PR DESCRIPTION
## Description

This implements some minor changes which will then allow to pass remote uris (http/https) to the contructors of, e.g., TransportNetwork. That way, GTFS schedules, for instance, can be read from a web site

Fixes #534 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Documentation update
- [ ] Refactoring
- [x] Tests
- [ ] CI/CD improvement

## Checklist

Please check off the items you completed before requesting a review:

- [x] I have read the [CONTRIBUTING
  guide](https://r5py.readthedocs.io/en/stable/contributing/CONTRIBUTING.html).
- [x] I have added tests that prove my fix is effective or that my feature
  works.
- [x] I have added or updated documentation where necessary, and ensured it
  fulfills the `pydocstyle` standards.
- [x] I have formatted my code with `black` and ensured linting passes
  (`flake8`).
- [x] I have made sure my code follows the style guidelines of this project.
- [x] I have rebased/merged the latest changes from `main`.
- [x] I have verified that CI passes after my changes.

## Additional notes

This is currently at a POC stage, still needs some work. Main change still needed: expiring cached copies of files. 
