### PR TITLE
reproject before+after snapping (v1.1.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- **1.1.6** (2026-05-27):
+    - snap_to_network() works with any CRS
+
 - **1.1.5** (2026-05-20):
     - allow input data sets to be remote URLs
 

--- a/src/r5py/__init__.py
+++ b/src/r5py/__init__.py
@@ -2,7 +2,7 @@
 
 """Python wrapper for the R5 routing analysis engine."""
 
-__version__ = "1.1.5"
+__version__ = "1.1.6"
 
 
 from .r5 import (

--- a/src/r5py/r5/isochrones.py
+++ b/src/r5py/r5/isochrones.py
@@ -16,7 +16,7 @@ import simplification.cutil
 from .base_travel_time_matrix import BaseTravelTimeMatrix
 from .transport_mode import TransportMode
 from .travel_time_matrix import TravelTimeMatrix
-from ..util import GoodEnoughEquidistantCrs, SpatiallyClusteredGeoDataFrame
+from ..util import SpatiallyClusteredGeoDataFrame
 
 __all__ = ["Isochrones"]
 
@@ -97,8 +97,6 @@ class Isochrones(BaseTravelTimeMatrix):
         """
         super().__init__(transport_network, **kwargs)
 
-        self.EQUIDISTANT_CRS = GoodEnoughEquidistantCrs(self.transport_network.extent)
-
         if isinstance(origins, shapely.Geometry):
             origins = geopandas.GeoDataFrame(
                 {
@@ -172,7 +170,7 @@ class Isochrones(BaseTravelTimeMatrix):
             if not reached_nodes.empty:
                 reached_nodes = SpatiallyClusteredGeoDataFrame(
                     reached_nodes, eps=(2.0 * self.point_grid_resolution)
-                ).to_crs(self.EQUIDISTANT_CRS)
+                ).to_crs(self.transport_network.EQUIDISTANT_CRS)
                 isochrone_polygons = pandas.concat(
                     [
                         (
@@ -193,7 +191,7 @@ class Isochrones(BaseTravelTimeMatrix):
                 isochrones["geometry"].append(isochrone_polygons)
 
         isochrones = geopandas.GeoDataFrame(
-            isochrones, geometry="geometry", crs=self.EQUIDISTANT_CRS
+            isochrones, geometry="geometry", crs=self.transport_network.EQUIDISTANT_CRS
         )
 
         # clip smaller isochrones by larger isochrones
@@ -305,7 +303,7 @@ class Isochrones(BaseTravelTimeMatrix):
         extent = shapely.ops.transform(
             pyproj.Transformer.from_crs(
                 R5_CRS,
-                self.EQUIDISTANT_CRS,
+                self.transport_network.EQUIDISTANT_CRS,
                 always_xy=True,
             ).transform,
             self.transport_network.extent,
@@ -314,7 +312,7 @@ class Isochrones(BaseTravelTimeMatrix):
         grid = geohexgrid.make_grid_from_bounds(
             *extent.bounds,
             self.point_grid_resolution,
-            crs=self.EQUIDISTANT_CRS,
+            crs=self.transport_network.EQUIDISTANT_CRS,
         )
         grid["geometry"] = grid["geometry"].centroid
         grid["id"] = grid.index
@@ -336,7 +334,7 @@ class Isochrones(BaseTravelTimeMatrix):
                 (
                     pandas.concat([self.origins] * 2)  # workaround until
                     # https://github.com/pyproj4/pyproj/issues/1309 is fixed
-                    .to_crs(self.EQUIDISTANT_CRS)
+                    .to_crs(self.transport_network.EQUIDISTANT_CRS)
                     .buffer(speed * max(self.isochrones).total_seconds())
                     .to_crs(R5_CRS)
                 )

--- a/src/r5py/r5/transport_network.py
+++ b/src/r5py/r5/transport_network.py
@@ -18,7 +18,14 @@ from .elevation_model import ElevationModel
 from .street_layer import StreetLayer
 from .transit_layer import TransitLayer
 from .transport_mode import TransportMode
-from ..util import Config, contains_gtfs_data, FileDigest, start_jvm, WorkingCopy
+from ..util import (
+    Config,
+    contains_gtfs_data,
+    FileDigest,
+    GoodEnoughEquidistantCrs,
+    start_jvm,
+    WorkingCopy,
+)
 from ..util.exceptions import GtfsFileError
 
 import com.conveyal.analysis
@@ -176,6 +183,7 @@ class TransportNetwork:
             )
 
         self._transport_network = transport_network
+        self.EQUIDISTANT_CRS = GoodEnoughEquidistantCrs(self.extent)
 
     @classmethod
     def from_directory(cls, path):
@@ -298,12 +306,17 @@ class TransportNetwork:
             point geometries that have been snapped to the network,
             using the same index and order as the input `points`
         """
-        return points.apply(
-            functools.partial(
-                self.street_layer.find_split,
-                radius=radius,
-                street_mode=street_mode,
+        original_crs = points.crs
+        return (
+            points.to_crs("EPSG:4326")
+            .apply(
+                functools.partial(
+                    self.street_layer.find_split,
+                    radius=radius,
+                    street_mode=street_mode,
+                )
             )
+            .to_crs(original_crs)
         )
 
     @functools.cached_property

--- a/src/r5py/r5/trip_planner.py
+++ b/src/r5py/r5/trip_planner.py
@@ -21,7 +21,7 @@ from .transfer_leg import TransferLeg
 from .transit_leg import TransitLeg
 from .transport_mode import TransportMode
 from .trip import Trip
-from ..util import GoodEnoughEquidistantCrs, start_jvm
+from ..util import start_jvm
 
 import com.conveyal.r5
 import gnu.trove.map
@@ -61,10 +61,9 @@ class TripPlanner:
         self.request = request
         self._transfer_paths = {}
 
-        EQUIDISTANT_CRS = GoodEnoughEquidistantCrs(self.transport_network.extent)
         self._crs_transformer_function = pyproj.Transformer.from_crs(
             R5_CRS,
-            EQUIDISTANT_CRS,
+            self.transport_network.EQUIDISTANT_CRS,
             always_xy=True,
         ).transform
 


### PR DESCRIPTION
## Description

This allows snapping of `GeoSeries` in any CRS, while previously, `EPSG:4326` was silently assumed

Fixes #538 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Documentation update
- [ ] Refactoring
- [ ] Tests
- [ ] CI/CD improvement

## Checklist

Please check off the items you completed before requesting a review:

- [x] I have read the [CONTRIBUTING
  guide](https://r5py.readthedocs.io/en/stable/contributing/CONTRIBUTING.html).
- [ ] I have added tests that prove my fix is effective or that my feature
  works.
- [x] I have added or updated documentation where necessary, and ensured it
  fulfills the `pydocstyle` standards.
- [x] I have formatted my code with `black` and ensured linting passes
  (`flake8`).
- [x] I have made sure my code follows the style guidelines of this project.
- [x] I have rebased/merged the latest changes from `main`.
- [ ] I have verified that CI passes after my changes.