### PR TITLE
Use pandas’ `__repr__()` for matrices etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- **1.1.7** (2026-06-29):
+    - Show matrix data when `print()`ing
+    - Address deprecation of datetime64(NaT) in Numpy 2.5
+
 - **1.1.6** (2026-05-27):
     - snap_to_network() works with any CRS
 

--- a/src/r5py/__init__.py
+++ b/src/r5py/__init__.py
@@ -2,7 +2,7 @@
 
 """Python wrapper for the R5 routing analysis engine."""
 
-__version__ = "1.1.6"
+__version__ = "1.1.7"
 
 
 from .r5 import (

--- a/src/r5py/r5/base_travel_time_matrix.py
+++ b/src/r5py/r5/base_travel_time_matrix.py
@@ -156,10 +156,6 @@ class BaseTravelTimeMatrix(geopandas.GeoDataFrame):
 
         self.verbose = Config().arguments.verbose
 
-    def __repr__(self):
-        """Return a string representation of `self`."""
-        return f"<{self.__class__.__name__}>"
-
     def __setattr__(self, attr, val):
         """Catch our own attributes here so we don’t mess with (geo)pandas columns."""
         if attr in self._r5py_attributes:

--- a/src/r5py/r5/trip_leg.py
+++ b/src/r5py/r5/trip_leg.py
@@ -35,7 +35,7 @@ class TripLeg:
     def __init__(
         self,
         transport_mode=None,
-        departure_time=numpy.datetime64("NaT"),  # noqa: B008
+        departure_time=numpy.datetime64("NaT", "s"),  # noqa: B008
         distance=None,
         travel_time=datetime.timedelta(seconds=0),  # noqa: B008
         wait_time=datetime.timedelta(seconds=0),  # noqa: B008
@@ -185,8 +185,8 @@ class TripLeg:
             or (self_column is None and other_column is None)
             or (self_column == numpy.nan and other_column == numpy.nan)
             or (
-                self_column == numpy.datetime64("NaT")
-                and other_column == numpy.datetime64("NaT")
+                self_column == numpy.datetime64("NaT", "s")
+                and other_column == numpy.datetime64("NaT", "s")
             )
         )
 

--- a/tests/test_travel_time_matrix.py
+++ b/tests/test_travel_time_matrix.py
@@ -541,7 +541,7 @@ class TestTravelTimeMatrix:
             origins=origins_valid_ids,
             departure=departure_datetime,
         )
-        assert repr(travel_time_matrix) == "<TravelTimeMatrix>"
+        assert repr(travel_time_matrix) == pandas.DataFrame.__repr__(travel_time_matrix)
 
     def test_transit_with_bicycle_access(
         self,


### PR DESCRIPTION
## Description

This pull request addresses issue #540. Previously, calling `print()` on a travel time matrix or other output data sets of r5py would only print the class name and memory address. This is counterintuitive if we want to make all output behave like `pandas.DataFrame`s or `geopandas.GeoDataFrame`s. 


Fixes #540, fixes #542

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Please check off the items you completed before requesting a review:

- [x] I have read the [CONTRIBUTING
  guide](https://r5py.readthedocs.io/en/stable/contributing/CONTRIBUTING.html).
- [x] I have formatted my code with `black` and ensured linting passes
  (`flake8`).
- [x] I have made sure my code follows the style guidelines of this project.
- [x] I have rebased/merged the latest changes from `main`.
- [ ] I have verified that CI passes after my changes.
