### PR TITLE
Python >=3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,11 +32,11 @@ jobs:
           - windows-latest
           - macos-latest
         python_version:
+          # - '3.15'
           - '3.14' 
           - '3.13'
           - '3.12'
           - '3.11'
-          - '3.10'
 
     steps:
       -  uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "simplification",
     "typing_extensions; python_version < '3.13'"
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/src/r5py/util/file_digest.py
+++ b/src/r5py/util/file_digest.py
@@ -28,13 +28,7 @@ class FileDigest(str):
             returns a hash sum
         """
         input_file = pathlib.Path(input_file)
-        try:
-            with input_file.open("rb") as f:
-                hashdigest = hashlib.file_digest(f, digest)
-        except AttributeError:  # Python<=3.10
-            hashdigest = hashlib.new(digest)
-            with input_file.open("rb") as f:
-                while data := f.read(BUFFER_SIZE):
-                    hashdigest.update(data)
+        with input_file.open("rb") as f:
+            hashdigest = hashlib.file_digest(f, digest)
 
         return hashdigest.hexdigest()

--- a/tests/test_detailed_itineraries.py
+++ b/tests/test_detailed_itineraries.py
@@ -13,8 +13,6 @@ import shapely
 import r5py
 import r5py.util.exceptions
 
-PANDAS_GT_2 = int(pandas.__version__.split(".")[0]) > 2
-
 
 class TestDetailedItinerariesInputValidation:
     @pytest.mark.parametrize(
@@ -528,19 +526,18 @@ class TestDetailedItineraries:
             "datetime64[ms]"
         )
 
-        if PANDAS_GT_2:  # pandas>=3.0.0: dtype(str)
-            for column in [
-                "agency_id",
-                "feed",
-                "route_id",
-                "start_stop_id",
-                "end_stop_id",
-            ]:
-                if travel_details[column].notnull().any():
-                    travel_details[column] = travel_details[column].fillna(
-                        numpy.nan
-                    )  # avoid mixed None, nan
-                    travel_details[column] = travel_details[column].astype("str")
+        for column in [
+            "agency_id",
+            "feed",
+            "route_id",
+            "start_stop_id",
+            "end_stop_id",
+        ]:
+            if travel_details[column].notnull().any():
+                travel_details[column] = travel_details[column].fillna(
+                    numpy.nan
+                )  # avoid mixed None, nan
+                travel_details[column] = travel_details[column].astype("str")
 
         travel_details = geopandas.GeoDataFrame(travel_details, crs="EPSG:4326")
 


### PR DESCRIPTION
## Description

The r5py codebase contains a few small workarounds to support Python < 3.11. In October 2026, Python 3.10 will be unsupported upstream, and we can remove the workarounds.

Fixes #458 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] Documentation update
- [x] Refactoring
- [ ] Tests
- [ ] CI/CD improvement

## Checklist

Please check off the items you completed before requesting a review:

- [x] I have read the [CONTRIBUTING
  guide](https://r5py.readthedocs.io/en/stable/contributing/CONTRIBUTING.html).
- [x] I have added tests that prove my fix is effective or that my feature
  works.
- [x] I have added or updated documentation where necessary, and ensured it
  fulfills the `pydocstyle` standards.
- [x] I have formatted my code with `black` and ensured linting passes
  (`flake8`).
- [x] I have made sure my code follows the style guidelines of this project.
- [x] I have rebased/merged the latest changes from `main`.
- [ ] I have verified that CI passes after my changes.
